### PR TITLE
Fix rendering of ordered lists

### DIFF
--- a/example.md
+++ b/example.md
@@ -9,13 +9,21 @@ This is some text with *emphasis*, **double emphasis** and ***triple emphasis***
 There is also a list:
 
  * item a
+   * sub-item a
+   * sub-item b
  * item b
+   1. sub-item x
+   1. sub-item y
  * item c
 
 And an enumeration:
 
  1. item 1
+   * sub-item a
+   * sub-item b
  1. item 2
+   1. sub item x
+   1. sub item y
  1. item 3
 
 > Quotes should also be supported.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,13 @@ use ansi_term::{Colour, Style};
 
 struct AnsiTerm {
     name: String,
+    list_counter: u32,
+}
+
+impl AnsiTerm {
+    fn new(name: String) -> AnsiTerm {
+        AnsiTerm {name: name, list_counter: 0}
+    }
 }
 
 impl Render for AnsiTerm {
@@ -89,10 +96,16 @@ impl Render for AnsiTerm {
 
     fn list(&mut self, output: &mut Buffer, content: &Buffer, flags: list::List) {
         output.pipe(&content);
+        self.list_counter = 0;
     }
 
     fn list_item(&mut self, output: &mut Buffer, content: &Buffer, flags: list::List) {
-        output.write(&"- ".as_bytes());
+        if flags.contains(list::ORDERED) {
+            self.list_counter += 1;
+            output.write(&format!(" {}. ", self.list_counter).as_bytes());
+        } else {
+            output.write(&"- ".as_bytes());
+        }
         output.pipe(&content);
     }
 
@@ -127,7 +140,7 @@ fn main() {
     let md = Markdown::new(&text);
 
     // Create AnsiTerm instance
-    let mut terminal = AnsiTerm { name: "uxterm".to_string() };
+    let mut terminal = AnsiTerm::new("uxterm".to_string());
 
     // Print formatted contents to terminal
     println!("{}", terminal.render(&md).to_str().unwrap());


### PR DESCRIPTION
The type of the list is passed by the flags parameter.  So if we
encounter an ORDERED list we use the list_counter to format a numbered
list.  list() gets called whenever a new list starts, so we can reset
the list_counter there.

This probably doesn't work with nested lists.

Fixes #5
